### PR TITLE
feat: Swagger를 활용한 API 문서화 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,9 @@ repositories {
 
 dependencies {
 
+//Swagger
+    implementation ("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+
 //    Valid
     implementation("org.springframework.boot:spring-boot-starter-validation")
 

--- a/src/main/java/com/donjo/springauthcore/global/auth/JwtAuthorizationFilter.java
+++ b/src/main/java/com/donjo/springauthcore/global/auth/JwtAuthorizationFilter.java
@@ -35,7 +35,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String requestUrl = request.getRequestURL().toString();
         if (    requestUrl.contains("/auth") ||
                 requestUrl.contains("/users/login") ||
-                requestUrl.contains("/h2-console")
+                requestUrl.contains("/h2-console") ||
+                requestUrl.contains("/swagger") ||
+                requestUrl.contains("/v3/api-docs")
         ) {
             log.info("특정 경로 요청, 필터를 건너뜁니다: {}", requestUrl);
             filterChain.doFilter(request, response); // 필터 체인을 계속 진행

--- a/src/main/java/com/donjo/springauthcore/global/config/SwaggerConfig.java
+++ b/src/main/java/com/donjo/springauthcore/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.donjo.springauthcore.global.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // Security 스키마 정의
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        // Security 요구사항 정의
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme)) // Security 설정 추가
+                .addSecurityItem(securityRequirement) // 모든 API에 적용
+                .info(new Info()
+                        .title("CodeArena API")
+                        .description("JWT 인증이 필요한 REST API")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/com/donjo/springauthcore/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/donjo/springauthcore/global/config/WebSecurityConfig.java
@@ -61,6 +61,8 @@ public class WebSecurityConfig {
                         .requestMatchers("/users/login").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/error").permitAll()  // 서버 단에서 에러시 에러창 띄워주는 url
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
         );
 


### PR DESCRIPTION
- 프로젝트에 Swagger 의존성 추가
- API 탐색을 위한 Swagger UI 설정 완료
- 상세한 API 문서를 통해 개발자 경험 개선
- 기존 엔드포인트와 Swagger 연동 검증 완료

> Swagger API 문서
![Swagger 구현](https://github.com/user-attachments/assets/17372100-934f-469f-b156-cab5aaa6a3c3)
